### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "dependencies": {
+    "dompurify": "^3.2.6"
+  }
 }

--- a/web/app.js
+++ b/web/app.js
@@ -2,6 +2,7 @@
  * CryptoQuest Arbitrage Dashboard
  * Real-time monitoring and control interface for the arbitrage bot
  */
+import DOMPurify from 'dompurify';
 
 class ArbitrageDashboard {
     constructor() {
@@ -659,11 +660,12 @@ class ArbitrageDashboard {
         toast.className = `toast align-items-center text-bg-${type} border-0`;
         toast.setAttribute('role', 'alert');
         
+        const sanitizedMessage = DOMPurify.sanitize(message);
         toast.innerHTML = `
             <div class="d-flex">
                 <div class="toast-body">
                     <i class="fas fa-${this.getNotificationIcon(type)} me-2"></i>
-                    ${message}
+                    ${sanitizedMessage}
                 </div>
                 <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
             </div>


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/CQT_Arbitrage/security/code-scanning/2](https://github.com/CreoDAMO/CQT_Arbitrage/security/code-scanning/2)

To fix the issue, the `message` parameter should be sanitized or encoded before being embedded into the DOM. The best approach is to use a library like `DOMPurify` to sanitize the input, ensuring that any malicious scripts are removed. Alternatively, the `message` can be encoded using a function like `textContent` to prevent it from being interpreted as HTML.

**Steps to fix:**
1. Import the `DOMPurify` library to sanitize the `message` parameter.
2. Apply `DOMPurify.sanitize(message)` before embedding the `message` into the DOM.
3. Ensure that the sanitized `message` is used in the `toast.innerHTML` assignment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
