### PR TITLE
Potential fix for code scanning alert no. 6: Client-side cross-site scripting

### DIFF
--- a/web/dashboard.ts
+++ b/web/dashboard.ts
@@ -285,7 +285,7 @@ class CryptoQuestDashboard {
     const container = document.getElementById('arbitrage-opportunities');
     if (!container) return;
 
-    container.innerHTML = this.state.opportunities.map(opp => `
+    const sanitizedHTML = DOMPurify.sanitize(this.state.opportunities.map(opp => `
       <div class="opportunity-card" data-id="${opp.id}">
         <div class="opportunity-header">
           <span class="network-badge ${opp.sourcePool.network}">${opp.sourcePool.network.toUpperCase()}</span>
@@ -307,7 +307,8 @@ class CryptoQuestDashboard {
           Execute
         </button>
       </div>
-    `).join('');
+    `).join(''));
+    container.innerHTML = sanitizedHTML;
   }
 
   private getConfidenceClass(confidence: number): string {


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/CQT_Arbitrage/security/code-scanning/6](https://github.com/CreoDAMO/CQT_Arbitrage/security/code-scanning/6)

To fix the issue, we need to sanitize the dynamically generated HTML content before assigning it to `container.innerHTML`. The best way to achieve this is by using the `DOMPurify` library, which is already imported in the file. This library can sanitize the HTML content to remove any malicious scripts or tags.

Steps to fix:
1. Use `DOMPurify.sanitize` to sanitize the HTML content generated by the `map` function in `updateArbitrageUI`.
2. Replace the direct assignment to `container.innerHTML` with the sanitized content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
